### PR TITLE
Bugfix: Improve logic for retrieving and setting translatable attributes

### DIFF
--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -141,7 +141,6 @@ abstract class TranslatableAction extends ModelAction
     public function isTranslatableAttribute($key)
     {
         return $key !== 'translatable'
-            && $this->translatableDefaultLocale !== $this->translatableActiveLocale
             && !$this->model->hasRelation($key)
             && in_array($key, $this->model->getTranslatableAttributes());
     }

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -215,18 +215,14 @@ abstract class TranslatableAction extends ModelAction
 
         $result = '';
 
-        if ($locale == $this->translatableDefaultLocale) {
-            $result = $this->getAttributeFromData($this->model->getAttributes(), $key);
-        } else {
-            if (!array_key_exists($locale, $this->translatableAttributes)) {
-                $this->loadTranslatableAttributes($locale);
-            }
+        if (!array_key_exists($locale, $this->translatableAttributes)) {
+            $this->loadTranslatableAttributes($locale);
+        }
 
-            if ($this->hasTranslation($key, $locale)) {
-                $result = $this->getAttributeFromData($this->translatableAttributes[$locale], $key);
-            } elseif ($this->translatableUseFallback) {
-                $result = $this->getAttributeFromData($this->model->getAttributes(), $key);
-            }
+        if ($this->hasTranslation($key, $locale)) {
+            $result = $this->getAttributeFromData($this->translatableAttributes[$locale],$key);
+        } elseif ( $locale == $this->translatableDefaultLocale || $this->translatableUseFallback) {
+            $result = $this->getAttributeFromData( $this->model->getAttributes(),$key);
         }
 
         return $result;
@@ -238,17 +234,17 @@ abstract class TranslatableAction extends ModelAction
             $locale = $this->translatableActiveLocale;
         }
 
-        if ($locale == $this->translatableDefaultLocale) {
-            $attributes = $this->model->getAttributes();
-
-            return $this->setAttributeFromData($attributes, $key, $value);
-        }
-
         if (!array_key_exists($locale, $this->translatableAttributes)) {
             $this->loadTranslatableAttributes($locale);
         }
 
-        return $this->setAttributeFromData($this->translatableAttributes[$locale], $key, $value);
+        $this->setAttributeFromData($this->translatableAttributes[$locale],$key,$value);
+
+        if ($locale == $this->translatableActiveLocale) {
+            $this->model->setAttribute($key, $value);
+        }
+
+        return $value;
     }
 
     public function getTranslatableAttributes()

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -240,7 +240,11 @@ abstract class TranslatableAction extends ModelAction
         $this->setAttributeFromData($this->translatableAttributes[$locale],$key,$value);
 
         if ($locale == $this->translatableActiveLocale) {
-            $this->model->setAttribute($key, $value);
+
+            $attributes = $this->model->getAttributes();
+            $attributes[$key] = $value;
+
+            $this->model->setRawAttributes($attributes);
         }
 
         return $value;

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -219,9 +219,9 @@ abstract class TranslatableAction extends ModelAction
         }
 
         if ($this->hasTranslation($key, $locale)) {
-            $result = $this->getAttributeFromData($this->translatableAttributes[$locale],$key);
-        } elseif ( $locale == $this->translatableDefaultLocale || $this->translatableUseFallback) {
-            $result = $this->getAttributeFromData( $this->model->getAttributes(),$key);
+            $result = $this->getAttributeFromData($this->translatableAttributes[$locale], $key);
+        } elseif ($locale == $this->translatableDefaultLocale || $this->translatableUseFallback) {
+            $result = $this->getAttributeFromData($this->model->getAttributes(), $key);
         }
 
         return $result;
@@ -237,7 +237,7 @@ abstract class TranslatableAction extends ModelAction
             $this->loadTranslatableAttributes($locale);
         }
 
-        $this->setAttributeFromData($this->translatableAttributes[$locale],$key,$value);
+        $this->setAttributeFromData($this->translatableAttributes[$locale], $key, $value);
 
         if ($locale == $this->translatableActiveLocale) {
 


### PR DESCRIPTION
Issue: 

The translation system treated the default language differently from other languages.
Because of that, when the active language was the same as the default language, the system skipped translation loading and directly used the model’s current value instead.

The model’s current value could already contain another language’s text from the request lifecycle.
This caused the wrong language to appear, for example:
  -    Dutch (`nl`) showing English values
  -    translation tabs displaying incorrect text 
  -    frontend showing the wrong translation even though the database had the correct value

 In short: 
 translations were being saved correctly but the system was reading the wrong source for the default language.
 
 
 Solution: 
 * The fix was to make all languages behave the same way, including the default language.

* Instead of reading the default language directly from the model, the system now always loads translations through the translation layer.

* All locale values (`en`, `fr`, `nl`, etc.) are now stored and retrieved uniformly from the translation state/table.

* The special condition that skipped translation handling for the default language was removed.

* Result:
  * frontend and backend now show correct translations
  * default language no longer displays another locale’s value
  * all languages behave consistently during save and display operations

