### PR TITLE
Bugfix: Improve translatable attribute logic and fix translated saving issues for nested items

### DIFF
--- a/resources/views/_partials/formwidgets/trlmarkdowneditor/trlmarkdowneditor.blade.php
+++ b/resources/views/_partials/formwidgets/trlmarkdowneditor/trlmarkdowneditor.blade.php
@@ -2,7 +2,7 @@
     id="{{ $this->getId('trl-control') }}"
     data-control="trlmarkdowneditor"
     data-textarea-element="#{{ $this->getId('textarea') }}"
-    data-locale-active="{{ $activeLocale->code }}"
+    data-locale-active="{{ $activeLocale }}"
     data-placeholder-field="#{{ $this->getId('textarea') }}"
     class="field-translatable field-translatable-markdowneditor dropdown size-{{ $size }}"
 >

--- a/resources/views/_partials/formwidgets/trlrepeater/trlrepeater.blade.php
+++ b/resources/views/_partials/formwidgets/trlrepeater/trlrepeater.blade.php
@@ -2,7 +2,7 @@
     id="{{ $this->getId('trl-control') }}"
     class="field-translatable field-translatable-repeater"
     data-control="trlrepeater"
-    data-locale-active="{{ $activeLocale->code }}"
+    data-locale-active="{{ $activeLocale }}"
 >
     <div class="dropdown">
         <button

--- a/resources/views/_partials/formwidgets/trlricheditor/trlricheditor.blade.php
+++ b/resources/views/_partials/formwidgets/trlricheditor/trlricheditor.blade.php
@@ -2,7 +2,7 @@
     id="{{ $this->getId('trl-control') }}"
     data-control="trlricheditor"
     data-textarea-element="#{{ $this->getId('textarea') }}"
-    data-locale-active="{{ $activeLocale->code }}"
+    data-locale-active="{{ $activeLocale }}"
     data-placeholder-field="#{{ $this->getId('textarea') }}"
     class="field-translatable field-translatable-richeditor size-{{ $size }}"
 >

--- a/resources/views/_partials/formwidgets/trltext/trltext.blade.php
+++ b/resources/views/_partials/formwidgets/trltext/trltext.blade.php
@@ -5,7 +5,7 @@
         id="{{ $this->getId('trl-control') }}"
         class="field-translatable field-translatable-text dropdown"
         data-control="{{ $field->getConfig('controlType', 'translatable') }}"
-        data-locale-active="{{ $activeLocale->code }}"
+        data-locale-active="{{ $activeLocale }}"
         data-placeholder-field="#{{ $field->getId('placeholderField') }}"
     >
         <input

--- a/resources/views/_partials/formwidgets/trltextarea/trltextarea.blade.php
+++ b/resources/views/_partials/formwidgets/trltextarea/trltextarea.blade.php
@@ -5,7 +5,7 @@
         id="{{ $this->getId('trl-control') }}"
         class="field-translatable field-translatable-textarea dropdown"
         data-control="{{ $field->getConfig('controlType', 'translatable') }}"
-        data-locale-active="{{ $activeLocale->code }}"
+        data-locale-active="{{ $activeLocale }}"
         data-placeholder-field="#{{ $field->getId('placeholderField') }}"
     >
         <textarea

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -141,7 +141,6 @@ abstract class TranslatableAction extends ModelAction
     public function isTranslatableAttribute($key)
     {
         return $key !== 'translatable'
-            && $this->translatableDefaultLocale !== $this->translatableActiveLocale
             && !$this->model->hasRelation($key)
             && in_array($key, $this->model->getTranslatableAttributes());
     }

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -215,18 +215,14 @@ abstract class TranslatableAction extends ModelAction
 
         $result = '';
 
-        if ($locale == $this->translatableDefaultLocale) {
-            $result = $this->getAttributeFromData($this->model->getAttributes(), $key);
-        } else {
-            if (!array_key_exists($locale, $this->translatableAttributes)) {
-                $this->loadTranslatableAttributes($locale);
-            }
+        if (!array_key_exists($locale, $this->translatableAttributes)) {
+            $this->loadTranslatableAttributes($locale);
+        }
 
-            if ($this->hasTranslation($key, $locale)) {
-                $result = $this->getAttributeFromData($this->translatableAttributes[$locale], $key);
-            } elseif ($this->translatableUseFallback) {
-                $result = $this->getAttributeFromData($this->model->getAttributes(), $key);
-            }
+        if ($this->hasTranslation($key, $locale)) {
+            $result = $this->getAttributeFromData($this->translatableAttributes[$locale],$key);
+        } elseif ( $locale == $this->translatableDefaultLocale || $this->translatableUseFallback) {
+            $result = $this->getAttributeFromData( $this->model->getAttributes(),$key);
         }
 
         return $result;
@@ -238,17 +234,17 @@ abstract class TranslatableAction extends ModelAction
             $locale = $this->translatableActiveLocale;
         }
 
-        if ($locale == $this->translatableDefaultLocale) {
-            $attributes = $this->model->getAttributes();
-
-            return $this->setAttributeFromData($attributes, $key, $value);
-        }
-
         if (!array_key_exists($locale, $this->translatableAttributes)) {
             $this->loadTranslatableAttributes($locale);
         }
 
-        return $this->setAttributeFromData($this->translatableAttributes[$locale], $key, $value);
+        $this->setAttributeFromData($this->translatableAttributes[$locale],$key,$value);
+
+        if ($locale == $this->translatableActiveLocale) {
+            $this->model->setAttribute($key, $value);
+        }
+
+        return $value;
     }
 
     public function getTranslatableAttributes()

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -240,7 +240,11 @@ abstract class TranslatableAction extends ModelAction
         $this->setAttributeFromData($this->translatableAttributes[$locale],$key,$value);
 
         if ($locale == $this->translatableActiveLocale) {
-            $this->model->setAttribute($key, $value);
+
+            $attributes = $this->model->getAttributes();
+            $attributes[$key] = $value;
+
+            $this->model->setRawAttributes($attributes);
         }
 
         return $value;

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -103,10 +103,22 @@ abstract class TranslatableAction extends ModelAction
 
     public function performSetTranslatableAttribute($key, $value)
     {
-        $value = $this->setAttributeTranslatedValue($key, $value);
-        if ($this->model->hasSetMutator($key)) {
-            $method = 'set'.Str::studly($key).'Attribute';
-            $value = $this->model->{$method}($value);
+        if (is_array($value) && array_key_exists($this->translatableActiveLocale, $value)) {
+            foreach ($value as $locale => $_value) {
+                $this->setAttributeTranslatedValue($key, $_value, $locale);
+            }
+
+            return $this->getAttributeTranslatedValue($key,$this->translatableActiveLocale);
+        }
+
+        if ($this->translatableActiveLocale === $this->translatableDefaultLocale  && !is_array($value)) {
+            return $value;
+        } else {
+            $value = $this->setAttributeTranslatedValue($key, $value);
+            if ($this->model->hasSetMutator($key)) {
+                $method = 'set'.Str::studly($key).'Attribute';
+                $value = $this->model->{$method}($value);
+            }
         }
 
         return $value;

--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -219,9 +219,9 @@ abstract class TranslatableAction extends ModelAction
         }
 
         if ($this->hasTranslation($key, $locale)) {
-            $result = $this->getAttributeFromData($this->translatableAttributes[$locale],$key);
-        } elseif ( $locale == $this->translatableDefaultLocale || $this->translatableUseFallback) {
-            $result = $this->getAttributeFromData( $this->model->getAttributes(),$key);
+            $result = $this->getAttributeFromData($this->translatableAttributes[$locale], $key);
+        } elseif ($locale == $this->translatableDefaultLocale || $this->translatableUseFallback) {
+            $result = $this->getAttributeFromData($this->model->getAttributes(), $key);
         }
 
         return $result;
@@ -237,7 +237,7 @@ abstract class TranslatableAction extends ModelAction
             $this->loadTranslatableAttributes($locale);
         }
 
-        $this->setAttributeFromData($this->translatableAttributes[$locale],$key,$value);
+        $this->setAttributeFromData($this->translatableAttributes[$locale], $key, $value);
 
         if ($locale == $this->translatableActiveLocale) {
 

--- a/src/FormWidgets/TRLBase.php
+++ b/src/FormWidgets/TRLBase.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Str;
  */
 trait TRLBase
 {
-    public ?Language $activeLocale;
+    public string $activeLocale;
 
     public bool $isSupported;
 
@@ -26,7 +26,8 @@ trait TRLBase
 
     public function initLocale(): void
     {
-        $this->activeLocale = Language::getActiveLocale();
+        $localization = app('translator.localization');
+        $this->activeLocale = $localization->getLocale();
         $this->isSupported = Language::supportsLocale();
     }
 
@@ -67,7 +68,7 @@ trait TRLBase
 
         if ($this->model->methodExists($mutateMethod)) {
             $value = $this->model->$mutateMethod($locale);
-        } elseif ($this->activeLocale->code != $locale && $this->model->methodExists('getAttributeTranslatedValue')) {
+        } elseif ($this->activeLocale != $locale && $this->model->methodExists('getAttributeTranslatedValue')) {
             $value = $this->model->translatableNoFallbackLocale()->getAttributeTranslatedValue($key, $locale);
         } else {
             $value = $this->formField->value;
@@ -92,7 +93,7 @@ trait TRLBase
             }
         }
 
-        return array_get($localeData, $this->activeLocale->code, $value);
+        return array_get($localeData, $this->activeLocale, $value);
     }
 
     public function getLocaleSaveData()


### PR DESCRIPTION
This pull request addresses the following issues:

1. **Saving nested translatable items** – Fixes problems encountered when saving nested entries (such as menu options in add/edit page screens) that contain translatable attributes.  
2. **Frontend active locale display** – Corrects the dashboard behavior where an incorrect active locale was shown instead of the actual default locale, which previously led to logical errors during saving or display.

**Pending documentation update:**  
If a user has Language A set as the default active language in settings, they must enter values for Language A when adding or updating translatable items. Otherwise, a field validation error will be triggered (this is the intended behavior).


As per new logic/behavior:

1. When a language (e.g., Language A) is active, its values are stored both in the `igniter_translate_attributes` table and directly in the model’s attribute name. This keeps the two synchronized, with the model attribute serving as a fallback.

2. If the default language is switched from Language A to Language B, the system continues to function normally. When a value in Language B is missing, the fallback value stored in the model’s attribute (previously Language A) will be shown instead—this is the intended logical behavior. However, to maintain synchronization as described in point 1, the user must add values for Language B as well.

3.  The default language selected in the language settings will now be correctly displayed as active on the language indicator of each text field.